### PR TITLE
fix first_to_ascend function definition

### DIFF
--- a/schema/50_games.sql
+++ b/schema/50_games.sql
@@ -227,6 +227,7 @@ RETURNS TABLE (
   r_endtime        timestamp with time zone,
   r_endtime_fmt    text,
   r_endtime_raw    bigint,
+  r_wallclock      bigint,
   r_deathlev       int,
   r_hp             int,
   r_maxhp          int,


### PR DESCRIPTION
there was a type mismatch in column 16 (bigint/integer) because wallclock was missing from the defined return value